### PR TITLE
Updated vscode devDependency to fix broken URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
         "minimist": "^1.2.5",
         "tar": "^6.0.1",
         "typescript": "^2.6.1",
-        "vscode": "^1.1.21"
+        "vscode": "^1.1.37"
     },
     "dependencies": {
         "Builder": "^2.8.1",


### PR DESCRIPTION
The vscode package fetched data from a URL which has since been changed (see https://github.com/microsoft/vscode/issues/119822). This broke npm install. Updating to the latest version fixes this and allows npm install to work again.